### PR TITLE
Adding linux support for Slack

### DIFF
--- a/apps/win/slack.talon
+++ b/apps/win/slack.talon
@@ -1,4 +1,5 @@
 os: windows
+os: linux
 app: Slack
 app: slack.exe
 #todo: some sort of plugin, consolidate with teams or something?


### PR DESCRIPTION
Verified shortcuts are the same, not sure if the win folder should be renamed or a new win-linux folder made